### PR TITLE
TWAKE_HOST env variable

### DIFF
--- a/test/common/api.js
+++ b/test/common/api.js
@@ -13,7 +13,7 @@ assert(process.env.TWAKE_PASSWORD, 'env variable TWAKE_PASSWORD is missing')
 class Request {
 
     constructor({host, prefix}) {
-        this.host = host
+        this.host = process.env.TWAKE_HOST || host
         this.prefix = prefix
         this.token = null
 


### PR DESCRIPTION
`TWAKE_HOST` environment variable overrides the `host` value from config.json (default is `http://localhost:3123`)